### PR TITLE
Removing dependency on _testcapi

### DIFF
--- a/py_lets_be_quickly_rational/constants.py
+++ b/py_lets_be_quickly_rational/constants.py
@@ -2,11 +2,11 @@
 
 from __future__ import absolute_import
 
-from _testcapi import DBL_MIN, DBL_MAX
-
 import sys
 from math import sqrt
 
+DBL_MIN = sys.float_info.min
+DBL_MAX = sys.float_info.max
 DBL_EPSILON = sys.float_info.epsilon
 
 SQRT_DBL_EPSILON = sqrt(DBL_EPSILON)


### PR DESCRIPTION
As highlighted in https://github.com/vollib/py_vollib/issues/1 and https://github.com/vollib/py_vollib/issues/11.

Copy of https://github.com/vollib/py_lets_be_rational/pull/2.